### PR TITLE
Added SetBuffer to c extension and DriverAdaMatrix BiblioPixel driver

### DIFF
--- a/ada-matrix.py
+++ b/ada-matrix.py
@@ -1,0 +1,18 @@
+import time
+from rgbmatrix import Adafruit_RGBmatrix
+
+from bibliopixel.drivers.driver_base import *
+
+class DriverAdaMatrix(DriverBase):
+    """For Testing: Provides no ouput, just a valid interface"""
+    
+    def __init__(self, rows = 32, chain = 1):
+        """delay: time to wait in milliseconds to simulate actual hardware interface time"""
+        super(DriverAdaMatrix, self).__init__(rows*32*chain)
+        self._rows = rows
+        self._chain = chain
+        self._matrix = Adafruit_RGBmatrix(rows, chain)
+
+    #Push new data to strand
+    def update(self, data):
+        self._matrix.SetBuffer(data)


### PR DESCRIPTION
Added SetBuffer to the C python extension class which allows passing in a list of bytes representing the full display buffer.  This is _much_ faster than calling SetPixel from python on every pixel. First time ever working with Python C extensions though... fixing up my code won't hurt my feelings :)

Reason for this was to create a [BiblioPixel](https://github.com/ManiacalLabs/BiblioPixel) driver so that the matrix could be driven by BiblioPixel. The driver is fully functional, but performance is quite poor compared to, for example, LPD8806 strips. I assume this is because the Pi is also having to do all the multiplexing of the matrix manually, eating up CPU cycles.

Usage of driver is as follows:

``` python
from bibliopixel import *
import bibliopixel.colors as colors

driver = DriverAdaMatrix(rows=32, chain=1)
#MUST use serpentine=False because rgbmatrix handles the data that way
led = LEDMatrix(driver, 32, 32, serpentine=False)

from matrix_animations import *
import bibliopixel.log as log
log.setLogLevel(log.DEBUG)


try:
    anim = ScrollText(led, "Maniacal Labs!", size=4)
    anim.run()
except KeyboardInterrupt:
    led.all_off()
    led.update()

```
