### PR TITLE
Added RGB_SLOWDOWN_GPIO mode to support raspberry pi 2 without glitching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.a
+*.so
+/led-matrix
+/minimal-example
+/text-example

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -40,11 +40,17 @@ class GPIO {
   // Set the bits that are '1' in the output. Leave the rest untouched.
   inline void SetBits(uint32_t value) {
     gpio_port_[0x1C / sizeof(uint32_t)] = value;
+#if RGB_SLOWDOWN_GPIO
+    gpio_port_[0x1C / sizeof(uint32_t)] = value;
+#endif
   }
 
   // Clear the bits that are '1' in the output. Leave the rest untouched.
   inline void ClearBits(uint32_t value) {
     gpio_port_[0x28 / sizeof(uint32_t)] = value;
+#if RGB_SLOWDOWN_GPIO
+    gpio_port_[0x28 / sizeof(uint32_t)] = value;
+#endif
   }
 
   // Write all the bits of "value" mentioned in "mask". Leave the rest untouched.

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -10,6 +10,13 @@ TARGET=librgbmatrix.a
 # has uses inverse logic for the RGB bits. Attempt this
 #DEFINES+=-DINVERSE_RGB_DISPLAY_COLORS
 
+
+# Running on the Raspberry Pi 2 seems to require slowing down the GPIO
+# bit setting, or we get glitches in the display.  Uncomment this line
+# if you get glitching.
+#
+#DEFINES+=-DRGB_SLOWDOWN_GPIO
+
 DEFINES+=-DADAFRUIT_RGBMATRIX_HAT
 
 INCDIR=../include


### PR DESCRIPTION
When using the code from the adafruit repository for the led driver code with the adafruit hat and a raspberry pi 2, I would get a lot of glitches on the display.   This change made to the hzeller repo fixes that by slowing down the output on the GPIO pins.  
