### PR TITLE
Underscore, not dash in module name (PEP8)

### DIFF
--- a/ada_matrix.py
+++ b/ada_matrix.py
@@ -33,7 +33,7 @@ class DriverAdaMatrix(DriverBase):
 
 # from bibliopixel import *
 # import bibliopixel.colors as colors
-# from ada-matrix import DriverAdaMatrix
+# from ada_matrix import DriverAdaMatrix
 
 # driver = DriverAdaMatrix(rows=32, chain=1)
 # driver.SetPWMBits(6) #decrease bit-depth for better performance


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#package-and-module-names

The dash used in this file name causes a syntax error when attempting to import using the example code:

``` python
from ada-matrix import DriverAdaMatrix
```

After renaming the module `ada_matrix.py` and adjusting the example import, it works fine:

``` python
from ada_matrix import DriverAdaMatrix
```
