### PR TITLE
Artifacts can be left on 64x32 matrices with B+

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -11,9 +11,9 @@ TARGET=librgbmatrix.a
 #DEFINES+=-DINVERSE_RGB_DISPLAY_COLORS
 
 
-# Running on the Raspberry Pi 2 seems to require slowing down the GPIO
-# bit setting, or we get glitches in the display.  Uncomment this line
-# if you get glitching.
+# Running on the Raspberry Pi 2 (and sometimes the B+) seems to require 
+# slowing down the GPIO bit setting, or we get glitches in the display.  
+# Uncomment this line if you get glitching.
 #
 #DEFINES+=-DRGB_SLOWDOWN_GPIO
 

--- a/rgbmatrix.cc
+++ b/rgbmatrix.cc
@@ -7,8 +7,8 @@
   and the SetImage method.
   ------------------------------------------------------------------------*/
 
-#include <python2.7/Python.h>
-#include <python2.7/Imaging.h>
+#include <python3.4m/Python.h>
+#include <python3.4m/Imaging.h>
 #include "led-matrix.h"
 
 using rgb_matrix::GPIO;
@@ -292,14 +292,29 @@ static PyTypeObject RGBmatrixObjectType = {
 	0,                              // tp_free
 };
 
+static struct module_state _state;
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "rgbmatrix",
+        NULL,
+        sizeof(struct module_state),
+        PyMethodDef,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
 PyMODINIT_FUNC initrgbmatrix(void) { // Module initialization function
         PyObject* m;
 
 	if(io.Init() &&    // Set up GPIO pins.  MUST run as root.
-          (m = Py_InitModule("rgbmatrix", methods)) &&
+          (m = PyModule_Create(&moduledef)) &&
           (PyType_Ready(&RGBmatrixObjectType) >= 0)) {
                 Py_INCREF(&RGBmatrixObjectType);
                 PyModule_AddObject(m, "Adafruit_RGBmatrix",
                   (PyObject *)&RGBmatrixObjectType);
         }
+        return m;
 }

--- a/rgbmatrix.cc
+++ b/rgbmatrix.cc
@@ -292,13 +292,12 @@ static PyTypeObject RGBmatrixObjectType = {
 	0,                              // tp_free
 };
 
-static struct module_state _state;
 
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "rgbmatrix",
         NULL,
-        sizeof(struct module_state),
+        sizeof(RGBmatrixObject),
         PyMethodDef,
         NULL,
         NULL,


### PR DESCRIPTION
Using this feature with a classic B+ can resolve some artifacts, updating documentation accordingly.

See https://forums.adafruit.com/viewtopic.php?f=47&t=81453 for proof.
